### PR TITLE
Add full CO₂ support for MSENS modules in Ampio IN node

### DIFF
--- a/ampioin/db/devtypes.json
+++ b/ampioin/db/devtypes.json
@@ -618,6 +618,7 @@
           "db",
           "lux",
           "iaq",
+          "co2",
           "temp"
        ],
        "outoptions":[

--- a/ampioin/db/invaltypes.json
+++ b/ampioin/db/invaltypes.json
@@ -14,6 +14,7 @@
         "iaq": "Indoor Air Quality index [IAQ]",
         "rs": "Heating/Cooling zone set temperature",
         "temp": "Temperature [*C]",
+        "co2": "CO2 concentration [ppm]",
         "au": "Analog 8bit value",
         "au16": "Analog 16 bit value",
         "au32": "Analog 32 bit value",

--- a/ampioin/in.html
+++ b/ampioin/in.html
@@ -196,7 +196,14 @@
             });
             $('#node-input-valtype').on('change', function(){
                 let valuetype = $('#node-input-valtype').val();
-                if(valuetype == 'hum' || valuetype == 'absp' || valuetype == 'relp' || valuetype == 'db' || valuetype == 'lux' || valuetype == 'iaq' || valuetype == 'temp'){
+                if(valuetype == 'hum'  ||
+                   valuetype == 'absp' ||
+                   valuetype == 'relp' ||
+                   valuetype == 'db'   || 
+                   valuetype == 'lux'  || 
+                   valuetype == 'iaq'  || 
+                   valuetype == 'temp' ||
+                   valuetype == 'co2') {
                     $('#ioid').hide();
                     //document.getElementById("ioid").style.display = "none";
                 }

--- a/ampioin/in.js
+++ b/ampioin/in.js
@@ -45,6 +45,10 @@ module.exports = function(RED) {
                 node.valtype = 'au16l';
                 node.ioid = '5';
             break;
+            case 'co2':
+                node.valtype = 'au16l';
+                node.ioid = '7';
+            break;
             case 'temp':
                 node.valtype = 't';
                 node.ioid = '1';


### PR DESCRIPTION
This pull request adds proper support for CO₂ readings from Ampio MSENS modules to the node-red-contrib-ampio package.

MSENS already exposes CO₂ data through MSERV and MQTT using standard au16l channels (IOID 7), but the Node-RED integration did not provide a co2 value type. As a result, CO₂ was not available in the Ampio IN node selector, even though Ampio API, MSERV and MQTT expose it correctly.